### PR TITLE
Personal/mb/add implicit enum serialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### ✨ Added
 
 - `std::string` support in JSON serializer.
+- Native `enum class` support in JSON serializer.
 
 ### 🙌 Improvements
 

--- a/include/OpCoSerializer/Json/JsonTypeSerializer.hpp
+++ b/include/OpCoSerializer/Json/JsonTypeSerializer.hpp
@@ -65,6 +65,10 @@ namespace OpCoSerializer::Json
 
                 return object;
             }
+            else if constexpr (std::is_enum_v<T>)
+            {
+                return rapidjson::Value(static_cast<int32_t>(value));
+            }
             else
             {
                 return rapidjson::Value(value);
@@ -97,6 +101,10 @@ namespace OpCoSerializer::Json
                 });
 
                 return deserialized;
+            }
+            else if constexpr (std::is_enum_v<T>)
+            {
+                return static_cast<T>(value.Get<int32_t>());
             }
             else
             {

--- a/test/JsonSerializerTests.cpp
+++ b/test/JsonSerializerTests.cpp
@@ -76,6 +76,25 @@ struct WithNested final
     };
 };
 
+enum class TestEnum
+{
+    Value
+};
+
+struct WithEnum final
+{
+    TestEnum enumValue;
+
+    bool operator==(WithEnum const& other) const
+    {
+        return enumValue == other.enumValue;
+    }
+
+    static auto constexpr SerializerProperties() { 
+        return std::make_tuple(MakeProperty(&WithEnum::enumValue, "enum"));
+    };
+};
+
 TEST(JsonSerializer, SerializesExpectedString)
 {
     JsonSerializer serializer{};
@@ -137,6 +156,17 @@ TEST(JsonSerializer, NestedRoundTripTest)
     
     auto serialized = serializer.Serialize(value);
     auto deserialized = serializer.Deserialize<WithNested>(serialized);
+
+    ASSERT_EQ(value, deserialized);
+}
+
+TEST(JsonSerializer, EnumRoundTripTest)
+{
+    JsonSerializer serializer{};
+    WithEnum value = { TestEnum::Value };
+    
+    auto serialized = serializer.Serialize(value);
+    auto deserialized = serializer.Deserialize<WithEnum>(serialized);
 
     ASSERT_EQ(value, deserialized);
 }


### PR DESCRIPTION
So I forgot that `enum class` is not implicitly convertible to `int` and we need to handle that in the serializer...